### PR TITLE
prima: disable debugging and tracers

### DIFF
--- a/drivers/staging/prima/CORE/HDD/src/wlan_hdd_wext.c
+++ b/drivers/staging/prima/CORE/HDD/src/wlan_hdd_wext.c
@@ -5429,7 +5429,7 @@ static int __iw_get_char_setnone(struct net_device *dev,
                 }
 
                 tlState = smeGetTLSTAState(hHal, pHddStaCtx->conn_info.staId[0]);
-
+#ifdef TRACE_RECORD
                 buf = scnprintf(extra + len, WE_MAX_STR_LEN - len,
                         "\n HDD Conn State - %s "
                         "\n \n SME State:"
@@ -5449,9 +5449,11 @@ static int __iw_get_char_setnone(struct net_device *dev,
                         macTraceGetTLState(tlState)
                         );
                 len += buf;
+#endif
                 adapter_num++;
             }
 
+#ifdef TRACE_RECORD
             if (pMac) {
                 /* Printing Lim State starting with global lim states */
                 buf = scnprintf(extra + len, WE_MAX_STR_LEN - len,
@@ -5478,14 +5480,13 @@ static int __iw_get_char_setnone(struct net_device *dev,
                         macTraceGetLimSmeState(pMac->lim.gpSession[count].limSmeState),
                         macTraceGetLimMlmState(pMac->lim.gpSession[count].limMlmState)
                         );
-
                         len += buf;
                         check++;
                     }
                     count++;
                 }
             }
-
+#endif
             wrqu->data.length = strlen(extra)+1;
             break;
         }

--- a/drivers/staging/prima/CORE/SME/src/csr/csrApiRoam.c
+++ b/drivers/staging/prima/CORE/SME/src/csr/csrApiRoam.c
@@ -1041,10 +1041,11 @@ void csrAbortCommand( tpAniSirGlobal pMac, tSmeCmd *pCommand, tANI_BOOLEAN fStop
 
 void csrRoamSubstateChange( tpAniSirGlobal pMac, eCsrRoamSubState NewSubstate, tANI_U32 sessionId)
 {
+#ifdef TRACE_RECORD
     smsLog(pMac, LOG1, FL("CSR RoamSubstate: [ %s <== %s ]"),
            macTraceGetcsrRoamSubState(NewSubstate),
            macTraceGetcsrRoamSubState(pMac->roam.curSubState[sessionId]));
-
+#endif
     if(pMac->roam.curSubState[sessionId] == NewSubstate)
     {
        return;
@@ -1056,10 +1057,11 @@ eCsrRoamState csrRoamStateChange( tpAniSirGlobal pMac, eCsrRoamState NewRoamStat
 {
     eCsrRoamState PreviousState;
           
+#ifdef TRACE_RECORD
     smsLog(pMac, LOG1, FL("CSR RoamState[%hu]: [ %s <== %s ]"), sessionId,
            macTraceGetcsrRoamState(NewRoamState),
            macTraceGetcsrRoamState(pMac->roam.curState[sessionId]));
-
+#endif
     PreviousState = pMac->roam.curState[sessionId];
     
     if ( NewRoamState != pMac->roam.curState[sessionId] ) 
@@ -2684,11 +2686,12 @@ eHalStatus csrRoamIssueDisassociate( tpAniSirGlobal pMac, tANI_U32 sessionId,
     }
     
     
+#ifdef TRACE_RECORD
     smsLog(pMac, LOG2, FL("CSR Attempting to Disassociate Bssid="MAC_ADDRESS_STR
            " subState = %s reason=%d"),
            MAC_ADDR_ARRAY(bssId), macTraceGetcsrRoamSubState(NewSubstate),
            reasonCode);
-
+#endif
     csrRoamSubstateChange( pMac, NewSubstate, sessionId);
 
     status = csrSendMBDisassocReqMsg( pMac, sessionId, bssId, reasonCode );    
@@ -8362,10 +8365,12 @@ void csrRoamingStateMsgProcessor( tpAniSirGlobal pMac, void *pMsgBuf )
         // TODO Session Id need to be acquired in this function
         tANI_U32 sessionId = 0;
     pSmeRsp = (tSirSmeRsp *)pMsgBuf;
+#ifdef TRACE_RECORD
     smsLog(pMac, LOG2, FL("Message %d[0x%04X] received in substate %s"),
            pSmeRsp->messageType, pSmeRsp->messageType,
            macTraceGetcsrRoamSubState(
            pMac->roam.curSubState[pSmeRsp->sessionId]));
+#endif
     pSmeRsp->messageType = (pSmeRsp->messageType);
     pSmeRsp->length = (pSmeRsp->length);
     pSmeRsp->statusCode = (pSmeRsp->statusCode);
@@ -8410,9 +8415,11 @@ void csrRoamingStateMsgProcessor( tpAniSirGlobal pMac, void *pMsgBuf )
 //HO
                  CSR_IS_ROAM_SUBSTATE_DISASSOC_HO( pMac, pSmeRsp->sessionId )         )
             {
+#ifdef TRACE_RECORD
                 smsLog(pMac, LOG1, FL("eWNI_SME_DISASSOC_RSP subState = %s"),
                        macTraceGetcsrRoamSubState(
                        pMac->roam.curSubState[pSmeRsp->sessionId]));
+#endif
                 csrRoamRoamingStateDisassocRspProcessor( pMac, (tSirSmeDisassocRsp *)pSmeRsp );
 #ifdef DEBUG_ROAM_DELAY
                 vos_record_roam_event(e_SME_DISASSOC_COMPLETE, NULL, 0);
@@ -8455,12 +8462,13 @@ void csrRoamingStateMsgProcessor( tpAniSirGlobal pMac, void *pMsgBuf )
                                 eCSR_ROAM_RESULT_IBSS_PEER_DEPARTED);
             break;
         default:
+#ifdef TRACE_RECORD
             smsLog(pMac, LOG1,
                    FL("Unexpected message type = %d[0x%X] received in substate %s"),
                    pSmeRsp->messageType, pSmeRsp->messageType,
                    macTraceGetcsrRoamSubState(
                    pMac->roam.curSubState[pSmeRsp->sessionId]));
-
+#endif
             //If we are connected, check the link status change 
                         if(!csrIsConnStateDisconnected(pMac, sessionId))
                         {
@@ -9929,6 +9937,7 @@ void csrRoamCheckForLinkStatusChange( tpAniSirGlobal pMac, tSirSmeRsp *pSirMsg )
                         }
                         else
                         {
+#ifdef TRACE_RECORD
                             smsLog(pMac, LOGW,
                                    FL("Skipping csrScanForCapabilityChange as "
                                    "CSR is in state %s and sub-state %s"),
@@ -9936,6 +9945,7 @@ void csrRoamCheckForLinkStatusChange( tpAniSirGlobal pMac, tSirSmeRsp *pSirMsg )
                                    pMac->roam.curState[sessionId]),
                                    macTraceGetcsrRoamSubState(
                                    pMac->roam.curSubState[sessionId]));
+#endif
                             /* We ignore the caps change event if CSR is not in full connected state.
                              * Send one event to PE to reset limSentCapsChangeNtf
                              * Once limSentCapsChangeNtf set 0, lim can send sub sequent CAPS change event
@@ -10568,12 +10578,13 @@ void csrRoamWaitForKeyTimeOutHandler(void *pv)
     tCsrRoamSession *pSession = CSR_GET_SESSION( pMac, pInfo->sessionId );
     eHalStatus status = eHAL_STATUS_FAILURE;
 
+#ifdef TRACE_RECORD
     smsLog(pMac, LOGW, FL("WaitForKey timer expired in state=%s sub-state=%s"),
            macTraceGetNeighbourRoamState(
            pMac->roam.neighborRoamInfo.neighborRoamState),
            macTraceGetcsrRoamSubState(
            pMac->roam.curSubState[pInfo->sessionId]));
-
+#endif
     if( CSR_IS_WAIT_FOR_KEY( pMac, pInfo->sessionId ) )
     {
 #ifdef FEATURE_WLAN_LFR
@@ -10643,12 +10654,14 @@ eHalStatus csrRoamStartWaitForKeyTimer(tpAniSirGlobal pMac, tANI_U32 interval)
     if (csrNeighborRoamIsHandoffInProgress(pMac))
     {
         /* Disable heartbeat timer when hand-off is in progress */
+#ifdef TRACE_RECORD
         smsLog(pMac, LOG2, FL("disabling HB timer in state=%s sub-state=%s"),
                macTraceGetNeighbourRoamState(
                pMac->roam.neighborRoamInfo.neighborRoamState),
                macTraceGetcsrRoamSubState(
                pMac->roam.curSubState[pMac->roam.WaitForKeyTimerInfo.sessionId]
                ));
+#endif
         ccmCfgSetInt(pMac, WNI_CFG_HEART_BEAT_THRESHOLD, 0, NULL, eANI_BOOLEAN_FALSE);
     }
 #endif
@@ -10660,11 +10673,13 @@ eHalStatus csrRoamStartWaitForKeyTimer(tpAniSirGlobal pMac, tANI_U32 interval)
 
 eHalStatus csrRoamStopWaitForKeyTimer(tpAniSirGlobal pMac)
 {
+#ifdef TRACE_RECORD
     smsLog(pMac, LOG2, FL("WaitForKey timer stopped in state=%s sub-state=%s"),
            macTraceGetNeighbourRoamState(
            pMac->roam.neighborRoamInfo.neighborRoamState),
            macTraceGetcsrRoamSubState(
            pMac->roam.curSubState[pMac->roam.WaitForKeyTimerInfo.sessionId]));
+#endif
 #ifdef FEATURE_WLAN_LFR
     if (csrNeighborRoamIsHandoffInProgress(pMac))
     {
@@ -16057,10 +16072,12 @@ eHalStatus csrRoamOffloadScan(tpAniSirGlobal pMac, tANI_U8 command, tANI_U8 reas
    if ((pMac->roam.neighborRoamInfo.neighborRoamState == eCSR_NEIGHBOR_ROAM_STATE_INIT) &&
        (command != ROAM_SCAN_OFFLOAD_STOP))
    {
+#ifdef TRACE_RECORD
       VOS_TRACE(VOS_MODULE_ID_SME, VOS_TRACE_LEVEL_INFO,
                 FL("Scan Command not sent to FW with state = %s and cmd=%d\n"),
                 macTraceGetNeighbourRoamState(
                 pMac->roam.neighborRoamInfo.neighborRoamState), command);
+#endif
       return eHAL_STATUS_FAILURE;
    }
 

--- a/drivers/staging/prima/CORE/SME/src/csr/csrCmdProcess.c
+++ b/drivers/staging/prima/CORE/SME/src/csr/csrCmdProcess.c
@@ -46,12 +46,14 @@ eHalStatus csrMsgProcessor( tpAniSirGlobal pMac,  void *pMsgBuf )
     eHalStatus status = eHAL_STATUS_SUCCESS;
     tSirSmeRsp *pSmeRsp = (tSirSmeRsp *)pMsgBuf;
 
+#ifdef TRACE_RECORD
     smsLog(pMac, LOG2, FL("Message %d[0x%04X] received in curState %s"
            "and substate %s"),
            pSmeRsp->messageType, pSmeRsp->messageType,
            macTraceGetcsrRoamState(pMac->roam.curState[pSmeRsp->sessionId]),
            macTraceGetcsrRoamSubState(
            pMac->roam.curSubState[pSmeRsp->sessionId]));
+#endif
 
     // Process the message based on the state of the roaming states...
     

--- a/drivers/staging/prima/CORE/SME/src/csr/csrNeighborRoam.c
+++ b/drivers/staging/prima/CORE/SME/src/csr/csrNeighborRoam.c
@@ -270,10 +270,12 @@ static void csrNeighborRoamTriggerHandoff(tpAniSirGlobal pMac,
         }
         else
         {
+#ifdef TRACE_RECORD
             smsLog(pMac, LOGE, FL("11R Reassoc indication received in"
                    "unexpected state %s"),
                    macTraceGetNeighbourRoamState(
                    pNeighborRoamInfo->neighborRoamState));
+#endif
             VOS_ASSERT(0);
         }
     }
@@ -293,8 +295,10 @@ static void csrNeighborRoamTriggerHandoff(tpAniSirGlobal pMac,
             }
             else
             {
+#ifdef TRACE_RECORD
                 smsLog(pMac, LOGE, FL("ESE Reassoc indication received in unexpected state %s"),
                        macTraceGetNeighbourRoamState(pNeighborRoamInfo->neighborRoamState));
+#endif
                 VOS_ASSERT(0);
             }
         }
@@ -318,10 +322,12 @@ static void csrNeighborRoamTriggerHandoff(tpAniSirGlobal pMac,
                 }
                 else
                 {
+#ifdef TRACE_RECORD
                     smsLog(pMac, LOGE, FL("LFR Reassoc indication received in"
                            "unexpected state %s"),
                            macTraceGetNeighbourRoamState(
                            pNeighborRoamInfo->neighborRoamState));
+#endif
                     VOS_ASSERT(0);
                 }
             }
@@ -332,6 +338,7 @@ static void csrNeighborRoamTriggerHandoff(tpAniSirGlobal pMac,
                 {
                     csrNeighborRoamRequestHandoff(pMac);
                 }
+#ifdef TRACE_RECORD
                 else
                 {
                     smsLog(pMac, LOGE, FL("Non-11R Reassoc indication received in"
@@ -339,6 +346,7 @@ static void csrNeighborRoamTriggerHandoff(tpAniSirGlobal pMac,
                            macTraceGetNeighbourRoamState(
                            pNeighborRoamInfo->neighborRoamState));
                 }
+#endif
             }
 }
 
@@ -394,6 +402,7 @@ VOS_STATUS csrNeighborRoamUpdateFastRoamingEnabled(tpAniSirGlobal pMac, const v_
     {
         NEIGHBOR_ROAM_DEBUG(pMac, LOG2, FL("Currently in INIT state, Nothing to do"));
     }
+#ifdef TRACE_RECORD
     else
     {
         NEIGHBOR_ROAM_DEBUG(pMac, LOGE,
@@ -402,6 +411,7 @@ VOS_STATUS csrNeighborRoamUpdateFastRoamingEnabled(tpAniSirGlobal pMac, const v_
         pNeighborRoamInfo->neighborRoamState));
         vosStatus = VOS_STATUS_E_FAILURE;
     }
+#endif
     return vosStatus;
 }
 
@@ -517,6 +527,7 @@ VOS_STATUS csrNeighborRoamSetLookupRssiThreshold(tpAniSirGlobal pMac, v_U8_t nei
         pMac->roam.neighborRoamInfo.cfgParams.neighborLookupThreshold = neighborLookupRssiThreshold;
         pNeighborRoamInfo->currentNeighborLookupThreshold = pMac->roam.neighborRoamInfo.cfgParams.neighborLookupThreshold;
     }
+#ifdef TRACE_RECORD
     else
     {
         NEIGHBOR_ROAM_DEBUG(pMac, LOGE,
@@ -524,6 +535,7 @@ VOS_STATUS csrNeighborRoamSetLookupRssiThreshold(tpAniSirGlobal pMac, v_U8_t nei
         macTraceGetNeighbourRoamState(pNeighborRoamInfo->neighborRoamState));
         vosStatus = VOS_STATUS_E_FAILURE;
     }
+#endif
     return vosStatus;
 }
 
@@ -1098,10 +1110,12 @@ eHalStatus csrNeighborRoamPreauthRspHandler(tpAniSirGlobal pMac, tSirRetStatus l
     if ((pNeighborRoamInfo->neighborRoamState != eCSR_NEIGHBOR_ROAM_STATE_PREAUTHENTICATING) &&
         (pNeighborRoamInfo->neighborRoamState != eCSR_NEIGHBOR_ROAM_STATE_REPORT_SCAN))
     {
+#ifdef TRACE_RECORD
         NEIGHBOR_ROAM_DEBUG(pMac, LOGW,
         FL("Preauth response received in state %s"),
         macTraceGetNeighbourRoamState(
         pNeighborRoamInfo->neighborRoamState));
+#endif
         preauthProcessed = eHAL_STATUS_FAILURE;
         goto DEQ_PREAUTH;
     }
@@ -2032,10 +2046,12 @@ static eHalStatus csrNeighborRoamProcessScanComplete (tpAniSirGlobal pMac)
                 }
                 else
                 {
+#ifdef TRACE_RECORD
                     NEIGHBOR_ROAM_DEBUG(pMac, LOGE,
                     FL("No candidate found after scanning in state %s .. "),
                     macTraceGetNeighbourRoamState(
                     pNeighborRoamInfo->neighborRoamState));
+#endif
                     /* Handle it appropriately */
                     csrNeighborRoamHandleEmptyScanResult(pMac);
                 }
@@ -2044,10 +2060,12 @@ static eHalStatus csrNeighborRoamProcessScanComplete (tpAniSirGlobal pMac)
             case eCSR_NEIGHBOR_ROAM_STATE_REPORT_SCAN:
                 if (!tempVal)
                 {
+#ifdef TRACE_RECORD
                     smsLog(pMac, LOGE, FL("No candidate found after scanning"
                            "in state %s .. "),
                            macTraceGetNeighbourRoamState(
                            pNeighborRoamInfo->neighborRoamState));
+#endif
                     /* Stop the timer here as the same timer will be started again in CFG_CHAN_SCAN_STATE */
                     csrNeighborRoamTransitToCFGChanScan(pMac);
                 }
@@ -2057,11 +2075,12 @@ static eHalStatus csrNeighborRoamProcessScanComplete (tpAniSirGlobal pMac)
                 // Can come only in INIT state. Where in we are associated, we sent scan and user
                 // in the meantime decides to disassoc, we will be in init state and still received call
                 // back issued. Should not come here in any other state, printing just in case
+#ifdef TRACE_RECORD
                 VOS_TRACE (VOS_MODULE_ID_SME, VOS_TRACE_LEVEL_INFO, 
                            FL("State %s"),
                            macTraceGetNeighbourRoamState(
                            pNeighborRoamInfo->neighborRoamState));
-
+#endif
                 // Lets just exit out silently.
                 return eHAL_STATUS_SUCCESS;
          }
@@ -2208,10 +2227,12 @@ static eHalStatus csrNeighborRoamScanRequestCallback(tHalHandle halHandle, void 
 
         if (!csrRoamIsStaMode(pMac, sessionId))
         {
+#ifdef TRACE_RECORD
             smsLog(pMac, LOGE, FL("Ignoring scan request callback on non-infra"
                    "session %d in state %s"),
                     sessionId, macTraceGetNeighbourRoamState(
                     pNeighborRoamInfo->neighborRoamState));
+#endif
             vos_mem_free(pContext);
             return eHAL_STATUS_SUCCESS;
         }
@@ -2859,12 +2880,14 @@ void csrNeighborRoamNeighborScanTimerCallback(void *pv)
                     csrNeighborRoamPerformBgScan(pMac, sessionId);
                     break;
                 default:
+#ifdef TRACE_RECORD
                     smsLog(pMac, LOGE, FL("Neighbor scan callback received in"
                           "state %s, prev state = %s"),
                            macTraceGetNeighbourRoamState(
                            pNeighborRoamInfo->neighborRoamState),
                            macTraceGetNeighbourRoamState(
                            pNeighborRoamInfo->prevNeighborRoamState));
+#endif
                     break;
             }
             break;
@@ -3343,10 +3366,12 @@ VOS_STATUS csrNeighborRoamCreateChanListFromNeighborReport(tpAniSirGlobal pMac)
      * channels. There is no need to update.*/
     if (numChannels)
     {
+#ifdef TRACE_RECORD
         smsLog(pMac, LOG1, FL("IAPP Neighbor list callback received as expected"
                "in state %s."),
                macTraceGetNeighbourRoamState(
                pNeighborRoamInfo->neighborRoamState));
+#endif
         pNeighborRoamInfo->roamChannelInfo.IAPPNeighborListReceived = eANI_BOOLEAN_TRUE;
 #ifdef WLAN_FEATURE_ROAM_SCAN_OFFLOAD
         if (csrRoamIsRoamOffloadScanEnabled(pMac))
@@ -3453,10 +3478,12 @@ void csrNeighborRoamRRMNeighborReportResult(void *context, VOS_STATUS vosStatus)
             }
             break;
         default:
+#ifdef TRACE_RECORD
             smsLog(pMac, LOGE, FL("Neighbor result callback not expected in"
                    "state %s, Ignoring.."),
                    macTraceGetNeighbourRoamState(
                    pNeighborRoamInfo->neighborRoamState));
+#endif
             break;
     }
     return;
@@ -4159,10 +4186,12 @@ VOS_STATUS  csrNeighborRoamNeighborLookupDownEvent(tpAniSirGlobal pMac)
             }
             break;
         default:
+#ifdef TRACE_RECORD
             smsLog(pMac, LOGE, FL("DOWN event received in invalid"
                    "state %s ..Ignoring..."),
                    macTraceGetNeighbourRoamState(
                    pNeighborRoamInfo->neighborRoamState));
+#endif
             break;
             
     }
@@ -4279,6 +4308,7 @@ eHalStatus csrNeighborRoamIndicateDisconnect(tpAniSirGlobal pMac, tANI_U8 sessio
         smsLog(pMac, LOGE, FL("pSession is NULL "));
         return eHAL_STATUS_FAILURE;
     }
+#ifdef TRACE_RECORD
     VOS_TRACE(VOS_MODULE_ID_SME, VOS_TRACE_LEVEL_INFO,
                    FL("Disconnect indication on session %d in state %s"
                       "from BSSID : "
@@ -4286,7 +4316,7 @@ eHalStatus csrNeighborRoamIndicateDisconnect(tpAniSirGlobal pMac, tANI_U8 sessio
                    macTraceGetNeighbourRoamState(
                    pNeighborRoamInfo->neighborRoamState),
                    MAC_ADDR_ARRAY(pSession->connectedProfile.bssid));
- 
+#endif 
 #ifdef FEATURE_WLAN_LFR
     /*Free the current previous profile and move the current profile to prev profile.*/
     csrRoamFreeConnectProfile(pMac, pPrevProfile);
@@ -4406,10 +4436,12 @@ eHalStatus csrNeighborRoamIndicateDisconnect(tpAniSirGlobal pMac, tANI_U8 sessio
             break;
 
         default:
+#ifdef TRACE_RECORD
             NEIGHBOR_ROAM_DEBUG(pMac, LOGW, FL("Received disconnect event"
                                 "in state %s"),
                                 macTraceGetNeighbourRoamState(
                                 pNeighborRoamInfo->neighborRoamState));
+#endif
             NEIGHBOR_ROAM_DEBUG(pMac, LOGW, FL("Transitioning to INIT state"));
             CSR_NEIGHBOR_ROAM_STATE_TRANSITION(eCSR_NEIGHBOR_ROAM_STATE_INIT)
             pNeighborRoamInfo->roamChannelInfo.IAPPNeighborListReceived = eANI_BOOLEAN_FALSE;
@@ -4456,11 +4488,12 @@ eHalStatus csrNeighborRoamIndicateConnect(tpAniSirGlobal pMac, tANI_U8 sessionId
     {
         return eHAL_STATUS_FAILURE;
     }
+#ifdef TRACE_RECORD
     smsLog(pMac, LOG2, FL("Connect indication received with session id %d"
            "in state %s"),
            sessionId, macTraceGetNeighbourRoamState(
            pNeighborRoamInfo->neighborRoamState));
-
+#endif
     // Bail out if this is NOT a STA persona
     if (pMac->roam.roamSession[sessionId].pCurRoamProfile->csrPersona != VOS_STA_MODE)
     {
@@ -4611,10 +4644,12 @@ eHalStatus csrNeighborRoamIndicateConnect(tpAniSirGlobal pMac, tANI_U8 sessionId
 #endif
             break;
         default:
+#ifdef TRACE_RECORD
             smsLog(pMac, LOGE, FL("Connect event received in invalid state %s"
                    "..Ignoring..."),
                    macTraceGetNeighbourRoamState(
                    pNeighborRoamInfo->neighborRoamState));
+#endif
             break;
     }
     return status;
@@ -4934,9 +4969,11 @@ void csrNeighborRoamRequestHandoff(tpAniSirGlobal pMac)
 
     if (pMac->roam.neighborRoamInfo.neighborRoamState != eCSR_NEIGHBOR_ROAM_STATE_PREAUTH_DONE) 
     {
+#ifdef TRACE_RECORD
         smsLog(pMac, LOGE, FL("Roam requested when Neighbor roam is in %s state"),
                macTraceGetNeighbourRoamState(
                pMac->roam.neighborRoamInfo.neighborRoamState));
+#endif
         return;
     }
 

--- a/drivers/staging/prima/CORE/SME/src/sme_common/sme_Api.c
+++ b/drivers/staging/prima/CORE/SME/src/sme_common/sme_Api.c
@@ -2639,12 +2639,14 @@ eHalStatus sme_ScanRequest(tHalHandle hHal, tANI_U8 sessionId, tCsrScanRequest *
                     }
                     else
                     {
+#ifdef TRACE_RECORD
                         smsLog(pMac, LOGE, FL("Scan denied in state %s"
                                "(sub-state %s)"),
                                macTraceGetNeighbourRoamState(
                                pMac->roam.neighborRoamInfo.neighborRoamState),
                                macTraceGetcsrRoamSubState(
                                pMac->roam.curSubState[sessionId]));
+#endif
                         /*HandOff is in progress. So schedule this scan later*/
                         status = eHAL_STATUS_RESOURCES;
                     }

--- a/drivers/staging/prima/CORE/VOSS/inc/vos_trace.h
+++ b/drivers/staging/prima/CORE/VOSS/inc/vos_trace.h
@@ -95,10 +95,10 @@ typedef enum
 
 #include  <i_vos_trace.h>   
 
-#ifdef TRACE_RECORD
-
 #define CASE_RETURN_STRING( str )           \
     case ( ( str ) ): return( (tANI_U8*)(#str) );
+
+#ifdef TRACE_RECORD
 
 #define MTRACE(p) p
 #define NO_SESSION 0xFF

--- a/drivers/staging/prima/Kbuild
+++ b/drivers/staging/prima/Kbuild
@@ -49,13 +49,13 @@ CONFIG_QCOM_ESE_UPLOAD := n
 # Feature flags which are not (currently) configurable via Kconfig
 
 #Whether to build debug version
-BUILD_DEBUG_VERSION := 1
+BUILD_DEBUG_VERSION := 0
 
 #Enable this flag to build driver in diag version
-BUILD_DIAG_VERSION := 1
+BUILD_DIAG_VERSION := 0
 
 #Do we panic on bug?  default is to warn
-PANIC_ON_BUG := 1
+PANIC_ON_BUG := 0
 
 #Re-enable wifi on WDI timeout
 RE_ENABLE_WIFI_ON_WDI_TIMEOUT := 0


### PR DESCRIPTION
we use a stable driver and debugging
debugging should not be enabled on relase builds

patch reduces compiled driver size by 1275080b

Signed-off-by: Alin Jerpelea <alin.jerpelea@sonymobile.com>